### PR TITLE
Support for storage the state of SidebarForm

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -19,23 +19,19 @@
   "namespace": true,
   "bs-dependencies": [
     "reason-react",
+    "res-logger",
     "bs-css",
     "bs-css-emotion",
     "re-formality",
-    "bs-webapi"
+    "bs-webapi",
+    "decco"
   ],
   "bs-dev-dependencies": [],
-  "ppx-flags": [
-    "re-formality/ppx"
-  ],
+  "ppx-flags": ["res-logger/ppx", "re-formality/ppx", "decco/ppx"],
   "refmt": 3,
   "warnings": {
     "error": "+5",
     "number": "-44"
   },
-  "bsc-flags": [
-    "-bs-super-errors",
-    "-bs-no-version-header",
-    "-open Belt"
-  ]
+  "bsc-flags": ["-bs-super-errors", "-bs-no-version-header", "-open Belt"]
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "bs-css-emotion": "1.2.0",
     "bs-platform": "8.2.0",
     "bs-webapi": "0.19.1",
+    "decco": "^1.3.0",
     "re-formality": "4.0.0-beta.7",
     "react": "16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.3",
     "react-text-mask": "5.4.3",
-    "reason-react": "0.9.1"
+    "reason-react": "0.9.1",
+    "res-logger": "^2.0.0-beta.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Sidebar/SidebarForm.re
+++ b/src/components/Sidebar/SidebarForm.re
@@ -1,4 +1,5 @@
 include [%form
+          [@decco]
           type input = {
             title: string,
             description: string,
@@ -19,7 +20,30 @@ include [%form
 
 type submissionForm = Formality.submissionCallbacks(input, submissionError);
 
-let handleChange = Form.handleChange;
+module Storage = {
+  open Dom.Storage;
+
+  let key = "SidebarForm:state";
+
+  let get = () =>
+    Option.map(localStorage |> getItem(key), value =>
+      value |> Js.Json.parseExn |> input_decode
+    );
+
+  let update = (state: input) => {
+    input_encode(state) |> Js.Json.stringify |> setItem(key, _, localStorage);
+
+    state;
+  };
+};
+
+let handleChange = (updater, callback, event) => {
+  Form.handleChange(
+    updater,
+    (input: input, value) => {callback(input, value) |> Storage.update},
+    event,
+  );
+};
 
 let updateTitle = form =>
   handleChange(form.updateTitle, (input: input, title) => {...input, title});

--- a/src/lib/TimerValues.re
+++ b/src/lib/TimerValues.re
@@ -3,12 +3,25 @@ open TimerTypes;
 let darkThemeId = ID.generate();
 let cleanThemeId = ID.generate();
 
-let initialConfig: SidebarForm.output = {
+let baseConfig: SidebarForm.output = {
   title: {j|Some title|j},
   description: "Some description",
   time: "05:00",
   theme: cleanThemeId,
 };
+
+let initialConfig =
+  switch (SidebarForm.Storage.get()) {
+  | None => baseConfig
+  | Some(Ok(config)) => config
+  | Some(Error(error)) =>
+    [%log.error
+      "Storage#key: " ++ SidebarForm.Storage.key;
+      ("Parsing error", error)
+    ];
+
+    baseConfig;
+  };
 
 let cleanTheme = {
   id: cleanThemeId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3681,6 +3681,11 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decco@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/decco/-/decco-1.3.0.tgz#25a130a4638fcf2088f713fe871e58308604c0cb"
+  integrity sha512-pednHg+Skby+sw193hbHTRLihZskmXrPsVMlqL9XpuLm+HfwMgS76lFRAkTGAi3435q0TBygTpt8McVTyk4Sfw==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -9071,6 +9076,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+res-logger@^2.0.0-beta.2:
+  version "2.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/res-logger/-/res-logger-2.0.0-beta.2.tgz#1a8428cf5c9de839f5c34652c15921dd2e695531"
+  integrity sha512-UZrgEOhFLkQ1a510C7Dwf/fPnEb9KOIP2MGjj3I+oMFLtO/7TzbM8KgdPAJxS3E5sumOdw57GaybO1dAfyUx4w==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Qual o propósito desse PR?

- Rascunho de uma ideia para suportar salvar as configurações feitas no `Timerlab`

### Problemas

- Como os ids dos temas são gerados dinamicamente, ele até salva isso no JSON, mas como não vai ser o mesmo id ao recarregar a tela, seleciona sempre o primeiro tema de novo por padrão

### Ideias

- Permitir salvar explicitamente a configuração feita e nomear o timer configurado, pode salvar no `localStorage` e prover um acesso usando um parametro na query string, dessa maneira pode possuir várias configurações nomeadas
- Se fosse implementado uma funcionalidade dessas, poderia salvar somente no `sessionStorage` o estado atual e a ação explícita de salvar que iria para o `localStorage`
- Usar o [bs-json](https://github.com/glennsl/bs-json) para validar o decode/encode do JSON
- Efetuar `debounce` do update no `localStorage` para evitar atualizar o `localStorage` a cada mudança efetuada